### PR TITLE
Allow multiple tag quickscan and QR label option

### DIFF
--- a/app/Http/Controllers/Api/AssetsController.php
+++ b/app/Http/Controllers/Api/AssetsController.php
@@ -618,6 +618,40 @@ class AssetsController extends Controller
         return (new SelectlistTransformer)->transformSelectlist($assets);
     }
 
+    /**
+     * Returns a list of asset tags for select2 components
+     */
+    public function taglist(Request $request): array
+    {
+        $assets = Asset::select(['asset_tag'])
+            ->whereNotNull('asset_tag');
+
+        if ($request->filled('search')) {
+            $assets->where('asset_tag', 'LIKE', '%' . $request->input('search') . '%');
+        }
+
+        $assets = $assets->orderBy('asset_tag', 'ASC')->paginate(50);
+
+        $items = [];
+        foreach ($assets as $asset) {
+            $items[] = [
+                'id' => $asset->asset_tag,
+                'text' => $asset->asset_tag,
+            ];
+        }
+
+        return [
+            'results' => $items,
+            'pagination' => [
+                'more' => ($assets->currentPage() >= $assets->lastPage()) ? false : true,
+                'per_page' => $assets->perPage(),
+            ],
+            'total_count' => $assets->total(),
+            'page' => $assets->currentPage(),
+            'page_count' => $assets->lastPage(),
+        ];
+    }
+
 
     /**
      * Accepts a POST request to create a new asset

--- a/app/Http/Controllers/SettingsController.php
+++ b/app/Http/Controllers/SettingsController.php
@@ -794,6 +794,7 @@ class SettingsController extends Controller
         $setting->alt_barcode_enabled = $request->input('alt_barcode_enabled', '0');
         //QR-Code
         $setting->qr_text = $request->input('qr_text');
+        $setting->labels_qr_value = $request->input('labels_qr_value', 'asset_tag');
 
         if ($request->filled('labels_display_name')) {
             $setting->labels_display_name = 1;

--- a/database/migrations/2025_06_07_000000_add_labels_qr_value_to_settings_table.php
+++ b/database/migrations/2025_06_07_000000_add_labels_qr_value_to_settings_table.php
@@ -1,0 +1,20 @@
+<?php
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::table('settings', function (Blueprint $table) {
+            $table->string('labels_qr_value')->default('asset_tag')->after('qr_text');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('settings', function (Blueprint $table) {
+            $table->dropColumn('labels_qr_value');
+        });
+    }
+};

--- a/resources/lang/en-US/admin/settings/general.php
+++ b/resources/lang/en-US/admin/settings/general.php
@@ -180,6 +180,7 @@ return [
     'pwd_secure_uncommon_help'  => 'This will disallow users from using common passwords from the top 10,000 passwords reported in breaches.',
     'qr_help'                   => 'Enable QR Codes first to set this',
     'qr_text'                   => 'QR Code Text',
+    'qr_value'                  => 'Data Under QR Code',
     'saml'                      => 'SAML',
     'saml_title'                => 'Update SAML settings',
     'saml_help'                 => 'SAML settings',

--- a/resources/views/hardware/labels.blade.php
+++ b/resources/views/hardware/labels.blade.php
@@ -138,9 +138,13 @@ $qr_size = ($settings->alt_barcode_enabled=='1') && ($settings->label2_1d_type!=
                     N: {{ $asset->name }}
                 </div>
             @endif
-            @if (($settings->labels_display_tag=='1') && ($asset->asset_tag!=''))
+            @if ($settings->labels_qr_value == 'asset_tag' && $asset->asset_tag != '')
                 <div class="pull-left">
                     T: {{ $asset->asset_tag }}
+                </div>
+            @elseif ($settings->labels_qr_value == 'asset_id')
+                <div class="pull-left">
+                    ID: {{ $asset->id }}
                 </div>
             @endif
             @if (($settings->labels_display_serial=='1') && ($asset->serial!=''))

--- a/resources/views/hardware/quickscan-checkin.blade.php
+++ b/resources/views/hardware/quickscan-checkin.blade.php
@@ -29,17 +29,8 @@
                 <div class="box-body">
                     {{csrf_field()}}
 
-                    <!-- Asset Tag -->
-                    <div class="form-group {{ $errors->has('asset_tag') ? 'error' : '' }}">
-                        <label for="asset_tag" class="col-md-3 control-label" id="checkin_tag">{{ trans('general.asset_tag') }}</label>
-                        <div class="col-md-9">
-                            <div class="input-group col-md-11 required">
-                                <input type="text" class="form-control" name="asset_tag" id="asset_tag" value="{{ old('asset_tag') }}" required>
-
-                            </div>
-                            {!! $errors->first('asset_tag', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
-                        </div>
-                    </div>
+                    <!-- Asset Tags -->
+                    @include('partials.forms.edit.asset-tag-select', ['fieldname' => 'asset_tags', 'translated_name' => trans('general.asset_tag'), 'select_id' => 'asset_tags'])
 
                     <!-- Status -->
                     <div class="form-group {{ $errors->has('status_id') ? 'error' : '' }}">
@@ -131,41 +122,50 @@
 
             event.preventDefault();
 
-            var form = $("#checkin-form").get(0);
-            var formData = $('#checkin-form').serializeArray();
+            var tags = $('#asset_tags').val() || [];
+            formData = formData.filter(function(item){ return item.name !== 'asset_tags[]'; });
 
-            $.ajax({
-                url: "{{ route('api.asset.checkinbytag') }}",
-                type : 'POST',
-                headers: {
-                    "X-Requested-With": 'XMLHttpRequest',
-                    "X-CSRF-TOKEN": $('meta[name="csrf-token"]').attr('content')
-                },
-                dataType : 'json',
-                data : formData,
-                success : function (data) {
-                    if (data.status == 'success') {
-                        $('#checkedin tbody').prepend("<tr class='success'><td>" + data.payload.asset_tag + "</td><td>" + data.payload.model + "</td><td>" + data.payload.model_number + "</td><td>" + data.messages + "</td><td><i class='fas fa-check text-success'></i></td></tr>");
-
-                        @if ($user?->enable_sounds)
-                        var audio = new Audio('{{ config('app.url') }}/sounds/success.mp3');
-                        audio.play()
-                        @endif
-
-                        incrementOnSuccess();
-                    } else {
-                        handlecheckinFail(data);
-                    }
-                    $('input#asset_tag').val('');
-                },
-                error: function (data) {
-                    handlecheckinFail(data);
-                },
-                complete: function() {
+            function sendNextTag() {
+                if(tags.length === 0){
                     $('#checkin-loader').hide();
+                    return;
                 }
+                var asset_tag = tags.shift();
+                var data = formData.slice();
+                data.push({name:'asset_tag', value:asset_tag});
+                $.ajax({
+                    url: "{{ route('api.asset.checkinbytag') }}",
+                    type : 'POST',
+                    headers: {
+                        "X-Requested-With": 'XMLHttpRequest',
+                        "X-CSRF-TOKEN": $('meta[name=\"csrf-token\"]').attr('content')
+                    },
+                    dataType : 'json',
+                    data : data,
+                    success : function (data) {
+                        if (data.status == 'success') {
+                            $('#checkedin tbody').prepend("<tr class='success'><td>" + data.payload.asset_tag + "</td><td>" + data.payload.model + "</td><td>" + data.payload.model_number + "</td><td>" + data.messages + "</td><td><i class='fas fa-check text-success'></i></td></tr>");
+                            @if ($user?->enable_sounds)
+                            var audio = new Audio('{{ config('app.url') }}/sounds/success.mp3');
+                            audio.play()
+                            @endif
+                            incrementOnSuccess();
+                        } else {
+                            handlecheckinFail(data);
+                        }
+                    },
+                    error: function (data) {
+                        handlecheckinFail(data);
+                    },
+                    complete: function(){
+                        sendNextTag();
+                    }
+                });
+            }
 
-            });
+            sendNextTag();
+
+            $('#asset_tags').val(null).trigger('change');
 
             return false;
         });

--- a/resources/views/hardware/quickscan.blade.php
+++ b/resources/views/hardware/quickscan.blade.php
@@ -27,17 +27,8 @@
                     <div class="box-body">
                     {{csrf_field()}}
 
-                    <!-- Next Audit -->
-                        <div class="form-group {{ $errors->has('asset_tag') ? 'error' : '' }}">
-                            <label for="asset_tag" class="col-md-3 control-label" id="audit_tag">{{ trans('general.asset_tag') }}</label>
-                            <div class="col-md-9">
-                                <div class="input-group date col-md-11 required" data-date-format="yyyy-mm-dd">
-                                    <input type="text" class="form-control" name="asset_tag" id="asset_tag" required value="{{ old('asset_tag') }}">
-
-                                </div>
-                                {!! $errors->first('asset_tag', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
-                            </div>
-                        </div>
+                    <!-- Asset Tags -->
+                    @include('partials.forms.edit.asset-tag-select', ['fieldname' => 'asset_tags', 'translated_name' => trans('general.asset_tag'), 'select_id' => 'asset_tags'])
 
 
 
@@ -138,43 +129,50 @@
 
             event.preventDefault();
 
-            var form = $("#audit-form").get(0);
-            var formData = $('#audit-form').serializeArray();
-            var asset_tag = $('#asset_tag').val();
+            var tags = $('#asset_tags').val() || [];
+            formData = formData.filter(function(item){ return item.name !== 'asset_tags[]'; });
 
-            $.ajax({
-                url: "{{ route('api.asset.audit.legacy') }}",
-                type : 'POST',
-                headers: {
-                    "X-Requested-With": 'XMLHttpRequest',
-                    "X-CSRF-TOKEN": $('meta[name="csrf-token"]').attr('content')
-                },
-                dataType : 'json',
-                data : formData,
-                success : function (data) {
-
-                    if (data.status == 'success') {
-                        $('#audited tbody').prepend("<tr class='success'><td>" + data.payload.asset_tag + "</td><td>" + data.messages + "</td><td><i class='fas fa-check text-success' style='font-size:18px;'></i></td></tr>");
-
-                        @if ($user->enable_sounds)
-                        var audio = new Audio('{{ config('app.url') }}/sounds/success.mp3');
-                        audio.play()
-                        @endif
-
-                        incrementOnSuccess();
-                    } else {
-                        handleAuditFail(data, asset_tag);
-                    }
-                    $('input#asset_tag').val('');
-                },
-                error: function (data) {
-                    handleAuditFail(data, asset_tag);
-                },
-                complete: function() {
+            function sendNext() {
+                if(tags.length === 0){
                     $('#audit-loader').hide();
+                    return;
                 }
+                var asset_tag = tags.shift();
+                var data = formData.slice();
+                data.push({name: 'asset_tag', value: asset_tag});
+                $.ajax({
+                    url: "{{ route('api.asset.audit.legacy') }}",
+                    type : 'POST',
+                    headers: {
+                        "X-Requested-With": 'XMLHttpRequest',
+                        "X-CSRF-TOKEN": $('meta[name="csrf-token"]').attr('content')
+                    },
+                    dataType : 'json',
+                    data : data,
+                    success : function (data) {
+                        if (data.status == 'success') {
+                            $('#audited tbody').prepend("<tr class='success'><td>" + data.payload.asset_tag + "</td><td>" + data.messages + "</td><td><i class='fas fa-check text-success' style='font-size:18px;'></i></td></tr>");
+                            @if ($user->enable_sounds)
+                            var audio = new Audio('{{ config('app.url') }}/sounds/success.mp3');
+                            audio.play()
+                            @endif
+                            incrementOnSuccess();
+                        } else {
+                            handleAuditFail(data, asset_tag);
+                        }
+                    },
+                    error: function (data) {
+                        handleAuditFail(data, asset_tag);
+                    },
+                    complete: function() {
+                        sendNext();
+                    }
+                });
+            }
 
-            });
+            sendNext();
+
+            $('#asset_tags').val(null).trigger('change');
 
             return false;
         });

--- a/resources/views/partials/forms/edit/asset-tag-select.blade.php
+++ b/resources/views/partials/forms/edit/asset-tag-select.blade.php
@@ -1,0 +1,14 @@
+<!-- Asset Tag Select -->
+<div class="form-group{{ $errors->has($fieldname ?? 'asset_tags') ? ' has-error' : '' }}">
+    <label for="{{ $fieldname ?? 'asset_tags' }}" class="col-md-3 control-label">{{ $translated_name ?? trans('general.asset_tag') }}</label>
+    <div class="col-md-7">
+        <select class="js-data-ajax select2" data-endpoint="hardware/taglist" data-placeholder="{{ trans('general.asset_tag') }}" aria-label="{{ $fieldname ?? 'asset_tags' }}" name="{{ ($fieldname ?? 'asset_tags').'[]' }}" id="{{ $select_id ?? 'asset_tags' }}" multiple style="width:100%">
+            @if(old($fieldname ?? 'asset_tags'))
+                @foreach(old($fieldname ?? 'asset_tags', []) as $tag)
+                    <option value="{{ $tag }}" selected="selected">{{ $tag }}</option>
+                @endforeach
+            @endif
+        </select>
+    </div>
+    {!! $errors->first($fieldname ?? 'asset_tags', '<div class="col-md-8 col-md-offset-3"><span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span></div>') !!}
+</div>

--- a/resources/views/settings/labels.blade.php
+++ b/resources/views/settings/labels.blade.php
@@ -270,7 +270,22 @@
                                             >
                                             <p class="help-block">{{ trans('admin/settings/general.qr_help') }}</p>
                                         @endif
-                                        {!! $errors->first('qr_text', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
+                                {!! $errors->first('qr_text', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
+                                   </div>
+                               </div>
+                                <div class="form-group">
+                                    <div class="col-md-3 text-right">
+                                    <label for="labels_qr_value" class="control-label">{{ trans('admin/settings/general.qr_value') }}</label>
+                                    </div>
+                                    <div class="col-md-7">
+                                        <x-input.select
+                                            name="labels_qr_value"
+                                            id="labels_qr_value"
+                                            :options="['none'=>trans('admin/settings/general.none'),'asset_tag'=>trans('admin/hardware/form.tag'),'asset_id'=>trans('admin/settings/general.asset_id')]"
+                                            :selected="old('labels_qr_value', $setting->labels_qr_value)"
+                                            style="width:100%"
+                                            aria-label="labels_qr_value"
+                                        />
                                     </div>
                                 </div>
 

--- a/routes/api.php
+++ b/routes/api.php
@@ -442,10 +442,16 @@ Route::group(['prefix' => 'v1', 'middleware' => ['api', 'api-throttle:api']], fu
 
         Route::get('selectlist',
             [
-                Api\AssetsController::class, 
+                Api\AssetsController::class,
                 'selectlist'
             ]
         )->name('assets.selectlist');
+
+        Route::get('taglist', [
+                Api\AssetsController::class,
+                'taglist'
+            ]
+        )->name('api.assets.taglist');
 
         Route::get('{asset_id}/licenses',
             [


### PR DESCRIPTION
## Summary
- support selecting multiple asset tags during bulk audit and quickscan checkin
- add endpoint for tag list
- allow choosing whether QR labels show tag, ID, or nothing
- migration for `labels_qr_value` setting

## Testing
- `php artisan test` *(fails: Class "SebastianBergmann\Environment\Console" not found)*

------
https://chatgpt.com/codex/tasks/task_b_6850eb5ecfd88325ba405e87d2337c9c